### PR TITLE
NSTA-71075: Chrome extension support for latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instana/synthetic-browser-script",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "A local runner to test and debug your browser scripts locally with CLI",
   "main": "dist/sbs-playback.js",
   "typings": "dist/src/main.d.ts",
@@ -14,6 +14,7 @@
     "dist/src/user",
     "dist/src/prepare/inject/mf-authentication.d.ts",
     "dist/bridge.js",
+    "dist/download-chrome.js",
     "dist/events.js",
     "dist/setup-node-sandbox.js",
     "dist/setup-sandbox.js",


### PR DESCRIPTION
## Why

From chrome version 142 onwards. Extension cannot be applied using --load-extension flag. 

## What

Added new flag --isLocalRun which will download latest version of  chrome for testing where --load-extension flag is still working


## References

Other artifacts related to this code change:
INSTA-71075
